### PR TITLE
add haskell syntax scope and add some colors

### DIFF
--- a/vs code/README.md
+++ b/vs code/README.md
@@ -3,7 +3,7 @@
 ## __settings.json__  
 ### __How to open__:  
 Menu:  
-- Win/Linux - __File__ > __Preferences__ > __Settings__  
+- Windows/Linux - __File__ > __Preferences__ > __Settings__  
 - macOS - __Code__ > __Preferences__ > __Settings__  
 
 Shortcut:  
@@ -19,8 +19,8 @@ __More info__:
 [User and Workspace Settings](https://code.visualstudio.com/docs/getstarted/settings)
 
 ### __Syntax Highlight__  
-> - View all current color value - Ctrl+Shift+P (Command Palette) with `Developer: Generate Color Theme From Current Settings`
-> - Debug grammars - Ctrl+Shift+P (Command Palette) with `Developer: Inspect TM Scopes`
+> - __View all current color value__ - Ctrl+Shift+P (Command Palette) with `Developer: Generate Color Theme From Current Settings`
+> - __Debug grammars__ - Ctrl+Shift+P (Command Palette) with `Developer: Inspect TM Scopes`
 
 
 __More info__: 

--- a/vs code/settings.json
+++ b/vs code/settings.json
@@ -16,23 +16,23 @@
     "editor.tokenColorCustomizations": {
         // https://code.visualstudio.com/api/language-extensions/syntax-highlight-guide
         "[Monokai]": {
-            // Haskell - these settings can't set inside specific language
+            // Haskell specific (using source.haskell scope)
             "textMateRules": [
                 {
-                    "scope": "keyword",
+                    "scope": "source.haskell keyword",
                     "settings": {
                         "foreground": "#a0a0a0",
                         "fontStyle": "bold",
                     },
                 },
                 {
-                    "scope": "constant.numeric",
+                    "scope": "source.haskell constant.numeric",
                     "settings": {
                         "foreground": "#e6db74",
                     },
                 },
                 {
-                    "scope": "constant.other ",
+                    "scope": "source.haskell constant.other ",
                     "settings": {
                         "foreground": "#ee956e",
                     },
@@ -48,10 +48,18 @@
     "workbench.editor.highlightModifiedTabs": true,
     "workbench.colorCustomizations": {
         // https://code.visualstudio.com/api/references/theme-color
+        "statusBar.background": "#007acc", // base
         "window.activeBorder": "#007acc",
+
+        "activityBar.inactiveForeground": "#858585", // base
         "window.inactiveBorder": "#858585",
-        "statusBar.background": "#007acc",
-        "activityBar.inactiveForeground": "#858585",
+        "statusBar.noFolderBackground": "#858585",
+
+        "editor.lineHighlightBackground": "#3e3d32", // base
+        "tab.activeBackground": "#3e3d32",
+
+        "breadcrumb.background": "#272822", // base
+        "tab.inactiveBackground": "#272822",
     },
 
     // Window


### PR DESCRIPTION
1. add Haskell scope for syntax highlight setting
2. add 
    - statusBar.noFolderBackground 
    - tab.inactiveBackground
    - tab.activeBackground

btw, colors comment with `// base` are there original color and as baselines of the following color(s)